### PR TITLE
Fix CI on activerecord v6.0.0.rc2

### DIFF
--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0.0.rc1"
+gem "rails", "~> 6.0.0.rc2"
 
 # c.f. https://github.com/rails/rails/blob/v6.0.0.rc1/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L13
 gem "sqlite3", "~> 1.4"

--- a/spec/db/setup.rb
+++ b/spec/db/setup.rb
@@ -32,7 +32,9 @@ end
 
 def up_migrate
   # db:migrate
-  if ActiveRecord.version >= Gem::Version.create("5.2.0")
+  if ActiveRecord.version >= Gem::Version.create("6.0.0.rc2")
+    ActiveRecord::MigrationContext.new(migrate_dir, ActiveRecord::SchemaMigration).up
+  elsif ActiveRecord.version >= Gem::Version.create("5.2.0")
     ActiveRecord::MigrationContext.new(migrate_dir).up
   else
     ActiveRecord::Migrator.up(migrate_dir)


### PR DESCRIPTION
```
  1) ActiveRecord::CompatibleLegacyMigration db:migrate should not output /DEPRECATION WARNING: Directly inheriting from ActiveRecord::Migration is deprecated/ to stderr
     Failure/Error: ActiveRecord::MigrationContext.new(migrate_dir).up

     ArgumentError:
       wrong number of arguments (given 1, expected 2)
     # ./gemfiles/vendor/bundle/ruby/2.5.0/gems/activerecord-6.0.0.rc2/lib/active_record/migration.rb:1020:in `initialize'
     # ./spec/db/setup.rb:36:in `new'
     # ./spec/db/setup.rb:36:in `up_migrate'
     # ./spec/active_record/compatible_legacy_migration_spec.rb:11:in `block (4 levels) in <top (required)>'
     # ./spec/active_record/compatible_legacy_migration_spec.rb:11:in `block (3 levels) in <top (required)>'
```

Close #20